### PR TITLE
Switch launch date to local time and show user local time inside tooltip

### DIFF
--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -19,10 +19,11 @@ import {
   Stack,
   AspectRatioBox,
   StatGroup,
+  Tooltip,
 } from "@chakra-ui/core";
 
 import { useSpaceX } from "../utils/use-space-x";
-import { formatDateTime } from "../utils/format-date";
+import { formatDateTime, formatDateTimeOffset } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 
@@ -124,7 +125,15 @@ function TimeAndLocation({ launch }) {
           </Box>
         </StatLabel>
         <StatNumber fontSize={["md", "xl"]}>
-          {formatDateTime(launch.launch_date_local)}
+          <Tooltip
+            placement="bottom"
+            label={formatDateTime(launch.launch_date_utc)}
+            aria-label="local time tooltip"
+          >
+            <span aria-label="local launch time">
+              {formatDateTimeOffset(launch.launch_date_local)}
+            </span>
+          </Tooltip>
         </StatNumber>
         <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>
       </Stat>

--- a/src/components/launch.test.js
+++ b/src/components/launch.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { CustomWrapper } from "../utils/custom-render";
 import LaunchPad from "./launch";
@@ -135,10 +135,19 @@ describe("Launch", () => {
   });
 
   test("renders the name of the mission", () => {
-    screen.getByText(launch.mission_name);
+    expect(screen.getByText(launch.mission_name)).toBeInTheDocument();
   });
+
   test("renders the main image and the gallery with all the images", () => {
     const images = screen.getAllByRole("img");
     expect(images.length).toBe(launch.links.flickr_images.length + 1);
+  });
+
+  test("renders the tooltip only when user hovers the local lauch date", async () => {
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    fireEvent.mouseOver(screen.getByLabelText("local launch time"));
+    const tooltip = await screen.findByRole("tooltip")
+    expect(tooltip).toBeInTheDocument();
   });
 });

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -15,6 +15,12 @@ export function formatDateTime(timestamp) {
     hour: "numeric",
     minute: "numeric",
     second: "numeric",
-    timeZoneName: "short",
   }).format(new Date(timestamp));
+}
+
+export function formatDateTimeOffset(timestamp) {
+  const offset = `UTC ${timestamp.slice(19, 25)}`;
+  const dateWithoutOffset = timestamp.slice(0, 19);
+  const date = formatDateTime(dateWithoutOffset);
+  return `${date} ${offset}`;
 }

--- a/src/utils/format-date.test.js
+++ b/src/utils/format-date.test.js
@@ -1,8 +1,27 @@
-import { formatDate } from "./format-date";
+import { formatDate, formatDateTimeOffset } from "./format-date";
 
-describe("formatDate", () => {
-  test("formats the date from UTC in ISO8601 to us-US long without the time", async () => {
-    const dateFromatted = formatDate("2020-11-21T17:17:00.000Z");
-    expect(dateFromatted).toBe("Saturday, November 21, 2020");
+describe("format date utils", () => {
+  describe("formatDate", () => {
+    test("formats the date from UTC in ISO8601 to us-US long without the time", async () => {
+      const dateFromatted = formatDate("2020-11-21T17:17:00.000Z");
+      expect(dateFromatted).toBe("Saturday, November 21, 2020");
+    });
+  });
+
+  describe("formatDateTimeOffset", () => {
+    test("formats the date from UTC in ISO8601 to us-US including the offset - negative offset", async () => {
+      const dateFromatted = formatDateTimeOffset("2020-11-21T09:17:00-08:00");
+      expect(dateFromatted).toBe("November 21, 2020, 9:17:00 AM UTC -08:00");
+    });
+
+    test("formats the date from UTC in ISO8601 to us-US including the offset - positive offset", async () => {
+      const dateFromatted = formatDateTimeOffset("2006-03-25T10:30:00+12:00");
+      expect(dateFromatted).toBe("March 25, 2006, 10:30:00 AM UTC +12:00");
+    });
+
+    test("formats the date from UTC in ISO8601 to us-US including the offset - zero offset", async () => {
+      const dateFromatted = formatDateTimeOffset("2006-03-25T10:30:00+00:00");
+      expect(dateFromatted).toBe("March 25, 2006, 10:30:00 AM UTC +00:00");
+    });
   });
 });


### PR DESCRIPTION
### Purpose
Fix the bug with the launch time being displayed on the launch profile screen.
It will now show the local launch time including the offset, plus the possibility to see the local user time inside a tooltip when hovering the latter.

### Implementation Approach
I have tried to make it as simple as possible, and re-use what we already have in place. Please check the implementation and let me know what you think about it, just to be sure I didn't misunderstand the issue.

As the `launch_date_local`  from the API is in UTC in ISO8601 (based on the documentation) I assumed the format won't change, so I just extracted the offset from that string, generating a new Javascript Date object with it and adding the offset at the end.
I have added a few test cases in order to cover different offsets.

>Side Note: As dealing with different timezones and formats becomes an issue, we might have to consider including an external library that does this for us, in order to avoid string manipulation. 

### Context
The team discovered that the launch DateTime on the launch details page (e.g.`/launches/92`) is displayed in the timezone of the app's user. However, the intent was to show it in the local timezone of the launch site instead (still displaying the timezone name or offset). After a discussion, the team decided to make the change, but keep the time in the user's timezone as a tooltip when hovering over the timestamp.
